### PR TITLE
chore: use base 12.0.0-libgbm instead of base 12.0.0

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -36,7 +36,7 @@ jobs:
   "node-12-0-0":
     <<: *defaults
     docker:
-      - image: cypress/base:12.0.0
+      - image: cypress/base:12.0.0-libgbm
         user: node
     steps:
       - install-and-test
@@ -45,7 +45,7 @@ jobs:
   "node-12-npm-ci":
     <<: *defaults
     docker:
-      - image: cypress/base:12.0.0
+      - image: cypress/base:12.0.0-libgbm
         user: node
     steps:
       - checkout
@@ -63,7 +63,7 @@ jobs:
   "node-12":
     <<: *defaults
     docker:
-      - image: cypress/base:12.0.0
+      - image: cypress/base:12.0.0-libgbm
         user: node
     steps:
       - install-and-test


### PR DESCRIPTION
electron 12 requires libgbm

base/12.0.0 doesn't have it
base/12.0.0-libgbm does